### PR TITLE
Group bloom filter bits into CPU L1 cache sized buckets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ BUILD_OS := $(shell uname)
 BUILD=$(TOP)/build
 INC=-I$(TOP) -I$(TOP)/murmur2
 LIB=-lm
-CC=gcc -Wall ${OPT} ${MM} -std=c99 -fPIC
+CC=gcc -Wall ${OPT} ${MM} -std=c99 -D_GNU_SOURCE -fPIC
 
 ifeq ($(MM),)
 MM=-m32

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,20 @@ lint:
 test: $(BUILD)/test-libbloom
 	$(BUILD)/test-libbloom
 
+HEAD          = $(shell git log -1 --format="%ci_%s" | perl -pe 's/[^\d\w\n]+/-/g')
+CPU_ID        = $(shell $(TOP)/make_util/cpu_id)
+PERF_TEST_DIR = $(TOP)/perf_test/$(HEAD)/$(CPU_ID)
+
+.PHONY: perf_test
+perf_test: $(BUILD)/test-libbloom
+	mkdir -p $(PERF_TEST_DIR)
+	perf stat $(BUILD)/test-libbloom -p  5000000  5000000 2>&1 | tee $(PERF_TEST_DIR)/test_1.log
+	perf stat $(BUILD)/test-libbloom -p 10000000 10000000 2>&1 | tee $(PERF_TEST_DIR)/test_2.log
+	perf stat $(BUILD)/test-libbloom -p 50000000 50000000 2>&1 | tee $(PERF_TEST_DIR)/test_3.log
+	git format-patch -1 -o $(TOP)/perf_test/$(HEAD)
+	lscpu > ${PERF_TEST_DIR}/lscpu.log
+	inxi -Cm -c0 > ${PERF_TEST_DIR}/inxi.log 2>/dev/null || inxi -C -c0 > ${PERF_TEST_DIR}/inxi.log
+
 gcov:
 	$(MAKE) clean
 	DEBUG=1 DEBUGOPT="-fprofile-arcs -ftest-coverage" $(MAKE) all

--- a/README
+++ b/README
@@ -18,6 +18,13 @@ for other build options.
 
 The shared library will be in ./build/libbloom.so
 
+Building optional 'perf_test' target assumes the next tools are available:
+- git
+- inxi (inxi -m requires make is run by root to use dmidecode)
+- lscpu
+- perf
+- perl
+
 
 Sample Usage
 ------------

--- a/bloom.c
+++ b/bloom.c
@@ -11,6 +11,7 @@
 
 #include <fcntl.h>
 #include <math.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -22,18 +23,19 @@
 #include "murmurhash2.h"
 
 
-static int test_bit_set_bit(unsigned char * bf, unsigned int x, int set_bit)
+static int test_bit_set_bit(unsigned char * buf, unsigned int x, int set_bit)
 {
-    unsigned int byte = x >> 3;
-    unsigned char c = bf[byte];        // expensive memory access
-    unsigned int mask = 1 << (x % 8);
+    register uint32_t  *word_buf = (uint32_t *) buf;
+    register unsigned int offset = x >> 5;
+    register uint32_t       word = word_buf[offset];
+    register unsigned int   mask = 1 << (x % 32);
 
-    if (c & mask)
+    if (word & mask)
         return 1;
     else
     {
         if (set_bit)
-            bf[byte] = c | mask;
+            word_buf[offset] = word | mask;
         return 0;
     }
 }

--- a/bloom.c
+++ b/bloom.c
@@ -9,6 +9,7 @@
  * Refer to bloom.h for documentation on the public interfaces.
  */
 
+#include <assert.h>
 #include <fcntl.h>
 #include <math.h>
 #include <stdint.h>
@@ -55,9 +56,12 @@ static int bloom_check_add(struct bloom * bloom,
   register unsigned int x;
   register unsigned int i;
 
+  unsigned       bucket_index = (a % bloom->buckets);
+  unsigned char *bucket_ptr   = (bloom->bf + (bucket_index << bloom->bucket_bytes_exponent));
+
   for (i = 0; i < bloom->hashes; i++) {
-    x = (a + i*b) % bloom->bits;
-    if (test_bit_set_bit(bloom->bf, x, add))
+    x = (a + i*b) & bloom->bucket_bits_fast_mod_operand;
+    if (test_bit_set_bit(bucket_ptr, x, add))
         hits++;
   }
 
@@ -68,6 +72,126 @@ static int bloom_check_add(struct bloom * bloom,
   return 0;
 }
 
+
+/**
+ * gets file 1st line (w/o new line character)
+ */
+static const char* get_file_content(int dir, const char* file)
+{
+  static char buf[128];
+  FILE *fp;
+  int fd = openat(dir, file, O_RDONLY);
+  if (fd < 0)
+    return NULL;
+
+  fp = fdopen(fd, "r");
+  int ok = fscanf(fp, "%127s", buf);
+  fclose(fp); // this also closes fd
+
+  return ok? buf : NULL;
+}
+
+
+static int apply_size_suffix(int val, char suffix, const char* errmsg)
+{
+  switch (suffix) {
+  case 'K':
+    return val * 1024;
+  case 'M':
+    return val * 1024*1024;
+  default:
+    printf("%s: Unknown suffix '%c'\n", errmsg, suffix);
+    return -1;
+  }
+}
+
+
+static unsigned make_log2_friendly(unsigned cache_size)
+{
+  return 1 << (int)log2(cache_size);
+}
+
+
+static unsigned detect_bucket_size(unsigned fallback_size)
+{
+  int dir;
+  const char *s;
+  char size_suffix;
+  static int bucket_size = 0;
+  if (bucket_size)
+    return bucket_size > 0 ? (bucket_size / BLOOM_L1_CACHE_SIZE_DIV) : fallback_size;
+
+  dir = open("/sys/devices/system/cpu/cpu0/cache/index0", O_DIRECTORY);
+  if (dir < 0)
+  {
+    // sorry, this works for Linux only
+    bucket_size = -1;
+    return fallback_size;
+  }
+
+  // Double check cache is L1
+  if (!(s = get_file_content(dir, "level")) || strcmp(s, "1") != 0)
+  {
+    printf("Cannot detect L1 cache size in %s:%d\n", __FILE__, __LINE__);
+    goto out_err;
+  }
+
+  // Double check cache type is "Data"
+  if (!(s = get_file_content(dir, "type")) || strcmp(s, "Data") != 0)
+  {
+    printf("Cannot detect L1 cache size in %s:%d\n", __FILE__, __LINE__);
+    goto out_err;
+  }
+
+  // Fetch L1 cache size
+  if (!(s = get_file_content(dir, "size")) || sscanf(s, "%d%c%c", &bucket_size, &size_suffix, &size_suffix) != 2)
+  {
+    printf("Cannot detect L1 cache size in %s:%d\n", __FILE__, __LINE__);
+    goto out_err;
+  }
+
+  bucket_size = apply_size_suffix(bucket_size, size_suffix, "Cannot detect L1 cache size");
+  if (bucket_size < 0)
+    goto out_err;
+
+  bucket_size  = make_log2_friendly(bucket_size);
+  bucket_size /= BLOOM_L1_CACHE_SIZE_DIV;
+
+  close(dir);
+  return bucket_size;
+
+out_err:
+  bucket_size = -1;
+  close(dir);
+  return fallback_size;
+}
+
+
+static void setup_buckets(struct bloom * bloom)
+{
+  const unsigned cache_size = detect_bucket_size(BLOOM_BUCKET_SIZE_FALLBACK);
+
+  bloom->buckets      = (bloom->bytes / cache_size);
+  bloom->bucket_bytes = cache_size;
+
+  // make sure bloom buffer bytes and bucket_bytes are even
+  int not_even_by = (bloom->bytes % bloom->bucket_bytes);
+  if (not_even_by)
+  {
+    // adjust bytes
+    bloom->bytes += (bloom->bucket_bytes - not_even_by);
+    assert((bloom->bytes % bloom->bucket_bytes) == 0 || !"Oops! Should get even");
+    // adjust bits
+    bloom->bits = bloom->bytes * 8;
+    // adjust bits per element
+    bloom->bpe = bloom->bits*1. / bloom->entries;
+    // adjust buckets
+    bloom->buckets++;
+  }
+
+  bloom->bucket_bytes_exponent        = __builtin_ctz(cache_size);
+  bloom->bucket_bits_fast_mod_operand = (cache_size * 8 - 1);
+}
 
 int bloom_init(struct bloom * bloom, int entries, double error)
 {
@@ -94,6 +218,8 @@ int bloom_init(struct bloom * bloom, int entries, double error)
   }
 
   bloom->hashes = (int)ceil(0.693147180559945 * bloom->bpe);  // ln(2)
+
+  setup_buckets(bloom);
 
   bloom->bf = (unsigned char *)calloc(bloom->bytes, sizeof(unsigned char));
   if (bloom->bf == NULL) {
@@ -125,6 +251,10 @@ void bloom_print(struct bloom * bloom)
   (void)printf(" ->bits = %d\n", bloom->bits);
   (void)printf(" ->bits per elem = %f\n", bloom->bpe);
   (void)printf(" ->bytes = %d\n", bloom->bytes);
+  (void)printf(" ->buckets = %u\n", bloom->buckets);
+  (void)printf(" ->bucket_bytes = %u\n", bloom->bucket_bytes);
+  (void)printf(" ->bucket_bytes_exponent = %u\n", bloom->bucket_bytes_exponent);
+  (void)printf(" ->bucket_bits_fast_mod_operand = 0%o\n", bloom->bucket_bits_fast_mod_operand);
   (void)printf(" ->hash functions = %d\n", bloom->hashes);
 }
 

--- a/bloom.h
+++ b/bloom.h
@@ -8,6 +8,17 @@
 #ifndef _BLOOM_H
 #define _BLOOM_H
 
+#define BLOOM_BUCKET_SIZE_FALLBACK (8 * 1024)
+
+/**
+ * It was found that using multiplier x0.5
+ * for CPU L1 cache size is more effective
+ * in terms of CPU usage and, surprisingly, collisions number.
+ *
+ * Feel free to tune this constant the way it will work for you.
+ */
+#define BLOOM_L1_CACHE_SIZE_DIV 1
+
 /** ***************************************************************************
  * Structure to keep track of one bloom filter.  Caller needs to
  * allocate this and pass it to the functions below. First call for
@@ -28,6 +39,12 @@ struct bloom
   // Fields below are private to the implementation. These may go away or
   // change incompatibly at any moment. Client code MUST NOT access or rely
   // on these.
+  unsigned buckets;
+  unsigned bucket_bytes;
+  // x86 CPU divide by/multiply by operation optimization helpers
+  unsigned bucket_bytes_exponent;
+  unsigned bucket_bits_fast_mod_operand;
+
   double bpe;
   unsigned char * bf;
   int ready;

--- a/make_util/cpu_id
+++ b/make_util/cpu_id
@@ -1,0 +1,10 @@
+#!/usr/bin/perl
+
+open LSCPU, "lscpu |" or die;
+while (<LSCPU>)
+{
+  /(.+?):\s+(.+)/;
+  $x{$1} = $2;
+}
+
+print "$x{'Vendor ID'}-$x{'CPU family'}.$x{Model}.$x{Stepping}_$x{'L1d cache'}\n"

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/0001-Add-build-support-on-Darwin.patch
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/0001-Add-build-support-on-Darwin.patch
@@ -1,0 +1,85 @@
+From 03c137273f334c9bd7c85d7a72d88d3e0bcaa417 Mon Sep 17 00:00:00 2001
+From: "Jyri J. Virkki" <jyri@virkki.com>
+Date: Tue, 2 Oct 2012 23:37:39 -0700
+Subject: [PATCH] Add build support on Darwin.
+
+---
+ Makefile | 18 +++++++++++++-----
+ test.c   |  5 +++--
+ 2 files changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index e8f90b5..5b7f064 100644
+--- a/Makefile
++++ b/Makefile
+@@ -26,7 +26,7 @@ BUILD_OS := $(shell uname)
+ BUILD=$(TOP)/build
+ INC=-I$(TOP) -I$(TOP)/murmur2
+ LIB=-lm
+-CC=gcc ${OPT} ${MM} -std=c99 -fPIC
++CC=gcc -Wall ${OPT} ${MM} -std=c99 -fPIC
+ 
+ ifeq ($(MM),)
+ MM=-m32
+@@ -34,10 +34,18 @@ endif
+ 
+ ifeq ($(BUILD_OS),Linux)
+ RPATH=-Wl,-rpath,$(BUILD)
++SO=so
+ endif
+ 
+ ifeq ($(BUILD_OS),SunOS)
+ RPATH=-R$(BUILD)
++SO=so
++endif
++
++ifeq ($(BUILD_OS),Darwin)
++MAC=-install_name $(BUILD)/libbloom.dylib
++RPATH=-Xlinker -rpath -Xlinker $(BUILD)
++SO=dylib
+ endif
+ 
+ ifeq ($(DEBUG),1)
+@@ -47,12 +55,12 @@ OPT=-O3
+ endif
+ 
+ 
+-all: $(BUILD)/libbloom.so $(BUILD)/test-libbloom
++all: $(BUILD)/libbloom.$(SO) $(BUILD)/test-libbloom
+ 
+-$(BUILD)/libbloom.so: $(BUILD)/murmurhash2.o $(BUILD)/bloom.o
+-	(cd $(BUILD) && $(CC) bloom.o murmurhash2.o -shared $(LIB) -o libbloom.so)
++$(BUILD)/libbloom.$(SO): $(BUILD)/murmurhash2.o $(BUILD)/bloom.o
++	(cd $(BUILD) && $(CC) bloom.o murmurhash2.o -shared $(LIB) $(MAC) -o libbloom.$(SO))
+ 
+-$(BUILD)/test-libbloom: $(BUILD)/libbloom.so $(BUILD)/test.o
++$(BUILD)/test-libbloom: $(BUILD)/libbloom.$(SO) $(BUILD)/test.o
+ 	(cd $(BUILD) && $(CC) test.o -L$(BUILD) $(RPATH) -lbloom -o test-libbloom)
+ 
+ $(BUILD)/%.o: %.c
+diff --git a/test.c b/test.c
+index 457925b..237de74 100644
+--- a/test.c
++++ b/test.c
+@@ -11,6 +11,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <sys/stat.h>
++#include <sys/time.h>
+ #include <sys/types.h>
+ #include <unistd.h>
+ 
+@@ -115,8 +116,8 @@ static void perf_loop(int entries, int count)
+   (void)gettimeofday(&tp, NULL);
+   long after = (tp.tv_sec * 1000L) + (tp.tv_usec / 1000L);
+ 
+-  (void)printf("Added %d elements of size %d, took %ldms (collisions=%d)\n",
+-               count, sizeof(int), after - before, collisions);
++  (void)printf("Added %d elements of size %d, took %d ms (collisions=%d)\n",
++               count, (int)sizeof(int), (int)(after - before), collisions);
+ 
+   (void)printf("%d,%d,%ld\n", entries, bloom.bytes, after - before);
+   bloom_free(&bloom);
+-- 
+2.1.4
+

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/inxi.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/inxi.log
@@ -1,0 +1,2 @@
+CPU:       Quad core Intel Pentium CPU N3530 (-MCP-) cache: 1024 KB flags: (lm nx pae sse sse2 sse3 sse4_1 sse4_2 ssse3 vmx) 
+           Clock Speeds: 1: 1494.00 MHz 2: 498.00 MHz 3: 498.00 MHz 4: 498.00 MHz

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/lscpu.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/lscpu.log
@@ -1,0 +1,18 @@
+Architecture:          i686
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                4
+On-line CPU(s) list:   0-3
+Thread(s) per core:    1
+Core(s) per socket:    4
+Socket(s):             1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 55
+Stepping:              8
+CPU MHz:               1992.000
+BogoMIPS:              4332.97
+Virtualization:        VT-x
+L1d cache:             24K
+L1i cache:             32K
+L2 cache:              1024K

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/test_1.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/test_1.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbf987028
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 71887937
+ ->bits per elem = 14.377588
+ ->bytes = 8985993
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 5743 ms (collisions=571)
+5000000,8985993,5743
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+       5748,977609 task-clock (msec)         #    0,998 CPUs utilized          
+               489 context-switches          #    0,085 K/sec                  
+                 7 cpu-migrations            #    0,001 K/sec                  
+               821 page-faults               #    0,143 K/sec                  
+    14 774 068 530 cycles                    #    2,570 GHz                     [49,97%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     1 927 195 585 instructions              #    0,13  insns per cycle         [74,99%]
+       227 197 117 branches                  #   39,520 M/sec                   [75,05%]
+        23 655 393 branch-misses             #   10,41% of all branches         [74,99%]
+
+       5,758358571 seconds time elapsed
+

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/test_2.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/test_2.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbf9461d8
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143775875
+ ->bits per elem = 14.377588
+ ->bytes = 17971985
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 11922 ms (collisions=1144)
+10000000,17971985,11922
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+      11924,768348 task-clock (msec)         #    0,998 CPUs utilized          
+             1 010 context-switches          #    0,085 K/sec                  
+                14 cpu-migrations            #    0,001 K/sec                  
+               971 page-faults               #    0,081 K/sec                  
+    30 669 783 333 cycles                    #    2,572 GHz                     [50,03%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     3 851 957 052 instructions              #    0,13  insns per cycle         [75,02%]
+       454 447 868 branches                  #   38,110 M/sec                   [74,99%]
+        47 012 464 branch-misses             #   10,34% of all branches         [74,99%]
+
+      11,942948021 seconds time elapsed
+

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/test_3.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.55.8_24K/test_3.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfdcd2a8
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 718879378
+ ->bits per elem = 14.377588
+ ->bytes = 89859923
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 63163 ms (collisions=5918)
+50000000,89859923,63163
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+      63152,305014 task-clock (msec)         #    0,999 CPUs utilized          
+             5 325 context-switches          #    0,084 K/sec                  
+                 8 cpu-migrations            #    0,000 K/sec                  
+             1 148 page-faults               #    0,018 K/sec                  
+   162 474 610 810 cycles                    #    2,573 GHz                     [50,00%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+    19 256 675 039 instructions              #    0,12  insns per cycle         [75,00%]
+     2 269 843 422 branches                  #   35,942 M/sec                   [75,00%]
+       234 928 831 branch-misses             #   10,35% of all branches         [75,00%]
+
+      63,230709769 seconds time elapsed
+

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/inxi.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/inxi.log
@@ -1,0 +1,7 @@
+CPU:       Quad core Intel Core i7-3632QM (-HT-MCP-) cache: 6144 KB 
+           clock speeds: max: 3200 MHz 1: 1202 MHz 2: 1309 MHz 3: 1203 MHz
+           4: 1473 MHz 5: 1292 MHz 6: 1361 MHz 7: 1298 MHz 8: 2988 MHz
+Memory:    Array-1 capacity: 16 GB devices: 2 EC: None
+           Device-1: Bottom-Slot 1(top) size: 4 GB speed: 1600 MHz type: DDR3
+           Device-2: Bottom-Slot 2(under) size: 4 GB speed: 1600 MHz
+           type: DDR3

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/lscpu.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/lscpu.log
@@ -1,0 +1,24 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                8
+On-line CPU(s) list:   0-7
+Thread(s) per core:    2
+Core(s) per socket:    4
+Socket(s):             1
+NUMA node(s):          1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 58
+Model name:            Intel(R) Core(TM) i7-3632QM CPU @ 2.20GHz
+Stepping:              9
+CPU MHz:               1789.820
+CPU max MHz:           3200,0000
+CPU min MHz:           1200,0000
+BogoMIPS:              4389.56
+Virtualization:        VT-x
+L1d cache:             32K
+L1i cache:             32K
+L2 cache:              256K
+L3 cache:              6144K
+NUMA node0 CPU(s):     0-7

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/test_1.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/test_1.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffc32cb0260
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 71887937
+ ->bits per elem = 14.377588
+ ->bytes = 8985993
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 1131 ms (collisions=571)
+5000000,8985993,1131
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+       1134,774465      task-clock (msec)         #    0,996 CPUs utilized          
+             1 139      context-switches          #    0,001 M/sec                  
+                 1      cpu-migrations            #    0,001 K/sec                  
+               731      page-faults               #    0,644 K/sec                  
+     3 452 630 950      cycles                    #    3,043 GHz                    
+     2 089 616 943      stalled-cycles-frontend   #   60,52% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     1 664 342 528      instructions              #    0,48  insns per cycle        
+                                                  #    1,26  stalled cycles per insn
+       219 022 779      branches                  #  193,010 M/sec                  
+        16 025 907      branch-misses             #    7,32% of all branches        
+
+       1,139372178 seconds time elapsed
+

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/test_2.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/test_2.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffd29ffcc30
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143775875
+ ->bits per elem = 14.377588
+ ->bytes = 17971985
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 2567 ms (collisions=1144)
+10000000,17971985,2567
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+       2562,999507      task-clock (msec)         #    0,996 CPUs utilized          
+             2 582      context-switches          #    0,001 M/sec                  
+                 3      cpu-migrations            #    0,001 K/sec                  
+               880      page-faults               #    0,343 K/sec                  
+     7 903 434 555      cycles                    #    3,084 GHz                    
+     5 152 565 493      stalled-cycles-frontend   #   65,19% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     3 316 867 977      instructions              #    0,42  insns per cycle        
+                                                  #    1,55  stalled cycles per insn
+       435 975 275      branches                  #  170,104 M/sec                  
+        32 019 836      branch-misses             #    7,34% of all branches        
+
+       2,573738552 seconds time elapsed
+

--- a/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/test_3.log
+++ b/perf_test/2012-10-02-23-37-39-0700_Add-build-support-on-Darwin-/GenuineIntel-6.58.9_32K/test_3.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffd33b88fd0
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 718879378
+ ->bits per elem = 14.377588
+ ->bytes = 89859923
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 13722 ms (collisions=5918)
+50000000,89859923,13722
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+      13727,703047      task-clock (msec)         #    0,996 CPUs utilized          
+            13 955      context-switches          #    0,001 M/sec                  
+                 6      cpu-migrations            #    0,000 K/sec                  
+               546      page-faults               #    0,040 K/sec                  
+    42 650 978 431      cycles                    #    3,107 GHz                    
+    28 897 120 020      stalled-cycles-frontend   #   67,75% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+    16 626 534 012      instructions              #    0,39  insns per cycle        
+                                                  #    1,74  stalled cycles per insn
+     2 187 344 109      branches                  #  159,338 M/sec                  
+       160 377 077      branch-misses             #    7,33% of all branches        
+
+      13,786753288 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/0001-Extract-function-refactoring-in-bloom_check_add.patch
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/0001-Extract-function-refactoring-in-bloom_check_add.patch
@@ -1,0 +1,66 @@
+From ccbc1b53528b5992582806506c3e06824d8e9879 Mon Sep 17 00:00:00 2001
+From: m0nkeyc0der <noface@inbox.ru>
+Date: Sun, 6 Sep 2015 14:10:08 +0300
+Subject: [PATCH] Extract function refactoring in bloom_check_add()
+
+---
+ bloom.c | 33 +++++++++++++++++++--------------
+ 1 file changed, 19 insertions(+), 14 deletions(-)
+
+diff --git a/bloom.c b/bloom.c
+index a433770..ec5b761 100644
+--- a/bloom.c
++++ b/bloom.c
+@@ -22,6 +22,23 @@
+ #include "murmurhash2.h"
+ 
+ 
++static int test_bit_set_bit(unsigned char * bf, unsigned int x, int set_bit)
++{
++    unsigned int byte = x >> 3;
++    unsigned char c = bf[byte];        // expensive memory access
++    unsigned int mask = 1 << (x % 8);
++
++    if (c & mask)
++        return 1;
++    else
++    {
++        if (set_bit)
++            bf[byte] = c | mask;
++        return 0;
++    }
++}
++
++
+ static int bloom_check_add(struct bloom * bloom,
+                            const void * buffer, int len, int add)
+ {
+@@ -35,23 +52,11 @@ static int bloom_check_add(struct bloom * bloom,
+   register unsigned int b = murmurhash2(buffer, len, a);
+   register unsigned int x;
+   register unsigned int i;
+-  register unsigned int byte;
+-  register unsigned int mask;
+-  register unsigned char c;
+ 
+   for (i = 0; i < bloom->hashes; i++) {
+     x = (a + i*b) % bloom->bits;
+-    byte = x >> 3;
+-    c = bloom->bf[byte];        // expensive memory access
+-    mask = 1 << (x % 8);
+-
+-    if (c & mask) {
+-      hits++;
+-    } else {
+-      if (add) {
+-        bloom->bf[byte] = c | mask;
+-      }
+-    }
++    if (test_bit_set_bit(bloom->bf, x, add))
++        hits++;
+   }
+ 
+   if (hits == bloom->hashes) {
+-- 
+2.1.4
+

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/inxi.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/inxi.log
@@ -1,0 +1,2 @@
+CPU:       Quad core Intel Pentium CPU N3530 (-MCP-) cache: 1024 KB flags: (lm nx pae sse sse2 sse3 sse4_1 sse4_2 ssse3 vmx) 
+           Clock Speeds: 1: 1494.00 MHz 2: 498.00 MHz 3: 1162.00 MHz 4: 498.00 MHz

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/lscpu.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/lscpu.log
@@ -1,0 +1,18 @@
+Architecture:          i686
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                4
+On-line CPU(s) list:   0-3
+Thread(s) per core:    1
+Core(s) per socket:    4
+Socket(s):             1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 55
+Stepping:              8
+CPU MHz:               2159.000
+BogoMIPS:              4332.99
+Virtualization:        VT-x
+L1d cache:             24K
+L1i cache:             32K
+L2 cache:              1024K

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/test_1.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/test_1.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfd76968
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 71887937
+ ->bits per elem = 14.377588
+ ->bytes = 8985993
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 6981 ms (collisions=571)
+5000000,8985993,6981
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+       6979,672083 task-clock (msec)         #    0,998 CPUs utilized          
+               602 context-switches          #    0,086 K/sec                  
+                 5 cpu-migrations            #    0,001 K/sec                  
+               820 page-faults               #    0,117 K/sec                  
+    17 935 500 801 cycles                    #    2,570 GHz                     [50,03%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     1 928 824 876 instructions              #    0,11  insns per cycle         [75,04%]
+       227 640 420 branches                  #   32,615 M/sec                   [74,99%]
+        23 531 726 branch-misses             #   10,34% of all branches         [75,00%]
+
+       6,994429380 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/test_2.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/test_2.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbffe7a88
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143775875
+ ->bits per elem = 14.377588
+ ->bytes = 17971985
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 14562 ms (collisions=1144)
+10000000,17971985,14562
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+      14560,404945 task-clock (msec)         #    0,998 CPUs utilized          
+             1 245 context-switches          #    0,086 K/sec                  
+                32 cpu-migrations            #    0,002 K/sec                  
+               970 page-faults               #    0,067 K/sec                  
+    37 367 895 890 cycles                    #    2,566 GHz                     [50,01%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     3 861 427 560 instructions              #    0,10  insns per cycle         [75,00%]
+       455 907 477 branches                  #   31,311 M/sec                   [74,98%]
+        47 302 266 branch-misses             #   10,38% of all branches         [75,01%]
+
+      14,590184486 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/test_3.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.55.8_24K/test_3.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfcaa098
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 718879378
+ ->bits per elem = 14.377588
+ ->bytes = 89859923
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 77002 ms (collisions=5918)
+50000000,89859923,77002
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+      76948,945827 task-clock (msec)         #    0,998 CPUs utilized          
+             6 768 context-switches          #    0,088 K/sec                  
+               261 cpu-migrations            #    0,003 K/sec                  
+             1 148 page-faults               #    0,015 K/sec                  
+   197 533 484 828 cycles                    #    2,567 GHz                     [49,99%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+    19 314 897 987 instructions              #    0,10  insns per cycle         [74,99%]
+     2 278 886 144 branches                  #   29,616 M/sec                   [75,00%]
+       237 150 887 branch-misses             #   10,41% of all branches         [75,01%]
+
+      77,112376005 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/inxi.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/inxi.log
@@ -1,0 +1,7 @@
+CPU:       Quad core Intel Core i7-3632QM (-HT-MCP-) cache: 6144 KB 
+           clock speeds: max: 3200 MHz 1: 3016 MHz 2: 2817 MHz 3: 2866 MHz
+           4: 2725 MHz 5: 2855 MHz 6: 2916 MHz 7: 2960 MHz 8: 3092 MHz
+Memory:    Array-1 capacity: 16 GB devices: 2 EC: None
+           Device-1: Bottom-Slot 1(top) size: 4 GB speed: 1600 MHz type: DDR3
+           Device-2: Bottom-Slot 2(under) size: 4 GB speed: 1600 MHz
+           type: DDR3

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/lscpu.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/lscpu.log
@@ -1,0 +1,24 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                8
+On-line CPU(s) list:   0-7
+Thread(s) per core:    2
+Core(s) per socket:    4
+Socket(s):             1
+NUMA node(s):          1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 58
+Model name:            Intel(R) Core(TM) i7-3632QM CPU @ 2.20GHz
+Stepping:              9
+CPU MHz:               3039.781
+CPU max MHz:           3200,0000
+CPU min MHz:           1200,0000
+BogoMIPS:              4389.56
+Virtualization:        VT-x
+L1d cache:             32K
+L1i cache:             32K
+L2 cache:              256K
+L3 cache:              6144K
+NUMA node0 CPU(s):     0-7

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/test_1.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/test_1.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffe118b6930
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 71887937
+ ->bits per elem = 14.377588
+ ->bytes = 8985993
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 1158 ms (collisions=571)
+5000000,8985993,1158
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+       1156,112933      task-clock (msec)         #    0,996 CPUs utilized          
+             1 161      context-switches          #    0,001 M/sec                  
+                 0      cpu-migrations            #    0,000 K/sec                  
+               730      page-faults               #    0,631 K/sec                  
+     3 532 105 264      cycles                    #    3,055 GHz                    
+     2 224 884 915      stalled-cycles-frontend   #   62,99% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     1 655 900 523      instructions              #    0,47  insns per cycle        
+                                                  #    1,34  stalled cycles per insn
+       217 555 635      branches                  #  188,179 M/sec                  
+        15 610 458      branch-misses             #    7,18% of all branches        
+
+       1,160181429 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/test_2.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/test_2.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7fffb3948d10
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143775875
+ ->bits per elem = 14.377588
+ ->bytes = 17971985
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 2587 ms (collisions=1144)
+10000000,17971985,2587
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+       2580,530996      task-clock (msec)         #    0,996 CPUs utilized          
+             2 639      context-switches          #    0,001 M/sec                  
+                 1      cpu-migrations            #    0,000 K/sec                  
+               879      page-faults               #    0,341 K/sec                  
+     7 977 628 048      cycles                    #    3,091 GHz                    
+     5 354 038 204      stalled-cycles-frontend   #   67,11% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     3 312 026 263      instructions              #    0,42  insns per cycle        
+                                                  #    1,62  stalled cycles per insn
+       435 161 092      branches                  #  168,632 M/sec                  
+        31 157 865      branch-misses             #    7,16% of all branches        
+
+       2,590338933 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/test_3.log
+++ b/perf_test/2015-09-08-22-12-32-0300_Extract-function-refactoring-in-bloom_check_add-/GenuineIntel-6.58.9_32K/test_3.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7fff65843be0
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 718879378
+ ->bits per elem = 14.377588
+ ->bytes = 89859923
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 13820 ms (collisions=5918)
+50000000,89859923,13820
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+      13790,739488      task-clock (msec)         #    0,996 CPUs utilized          
+            14 082      context-switches          #    0,001 M/sec                  
+                 7      cpu-migrations            #    0,001 K/sec                  
+             1 057      page-faults               #    0,077 K/sec                  
+    42 424 475 392      cycles                    #    3,076 GHz                    
+    29 358 467 422      stalled-cycles-frontend   #   69,20% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+    16 555 273 823      instructions              #    0,39  insns per cycle        
+                                                  #    1,77  stalled cycles per insn
+     2 174 994 692      branches                  #  157,714 M/sec                  
+       155 421 807      branch-misses             #    7,15% of all branches        
+
+      13,840859495 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/0001-test_bit_set_bit-address-a-word-instead-of-a-byte.patch
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/0001-test_bit_set_bit-address-a-word-instead-of-a-byte.patch
@@ -1,0 +1,52 @@
+From 7f6a04b92dda7746ea9dbb699ef75a213bbd5034 Mon Sep 17 00:00:00 2001
+From: m0nkeyc0der <noface@inbox.ru>
+Date: Sun, 6 Sep 2015 14:11:21 +0300
+Subject: [PATCH] test_bit_set_bit(): address a word instead of a byte
+
+The word is chosen to be 32 bit as
+the most common one among nowdays popular architectures.
+---
+ bloom.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/bloom.c b/bloom.c
+index ec5b761..d5c3869 100644
+--- a/bloom.c
++++ b/bloom.c
+@@ -11,6 +11,7 @@
+ 
+ #include <fcntl.h>
+ #include <math.h>
++#include <stdint.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
+@@ -22,18 +23,19 @@
+ #include "murmurhash2.h"
+ 
+ 
+-static int test_bit_set_bit(unsigned char * bf, unsigned int x, int set_bit)
++static int test_bit_set_bit(unsigned char * buf, unsigned int x, int set_bit)
+ {
+-    unsigned int byte = x >> 3;
+-    unsigned char c = bf[byte];        // expensive memory access
+-    unsigned int mask = 1 << (x % 8);
++    register uint32_t  *word_buf = (uint32_t *) buf;
++    register unsigned int offset = x >> 5;
++    register uint32_t       word = word_buf[offset];
++    register unsigned int   mask = 1 << (x % 32);
+ 
+-    if (c & mask)
++    if (word & mask)
+         return 1;
+     else
+     {
+         if (set_bit)
+-            bf[byte] = c | mask;
++            word_buf[offset] = word | mask;
+         return 0;
+     }
+ }
+-- 
+2.1.4
+

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/inxi.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/inxi.log
@@ -1,0 +1,2 @@
+CPU:       Quad core Intel Pentium CPU N3530 (-MCP-) cache: 1024 KB flags: (lm nx pae sse sse2 sse3 sse4_1 sse4_2 ssse3 vmx) 
+           Clock Speeds: 1: 2159.00 MHz 2: 830.00 MHz 3: 664.00 MHz 4: 2159.00 MHz

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/lscpu.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/lscpu.log
@@ -1,0 +1,18 @@
+Architecture:          i686
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                4
+On-line CPU(s) list:   0-3
+Thread(s) per core:    1
+Core(s) per socket:    4
+Socket(s):             1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 55
+Stepping:              8
+CPU MHz:               996.000
+BogoMIPS:              4332.99
+Virtualization:        VT-x
+L1d cache:             24K
+L1i cache:             32K
+L2 cache:              1024K

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/test_1.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/test_1.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfe71af8
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 71887937
+ ->bits per elem = 14.377588
+ ->bytes = 8985993
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 6455 ms (collisions=571)
+5000000,8985993,6455
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+       6317,264517 task-clock (msec)         #    0,977 CPUs utilized          
+             1 558 context-switches          #    0,247 K/sec                  
+                18 cpu-migrations            #    0,003 K/sec                  
+               820 page-faults               #    0,130 K/sec                  
+    16 226 518 272 cycles                    #    2,569 GHz                     [49,78%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     1 935 533 124 instructions              #    0,12  insns per cycle         [74,78%]
+       228 543 249 branches                  #   36,178 M/sec                   [75,15%]
+        22 776 826 branch-misses             #    9,97% of all branches         [75,07%]
+
+       6,465519444 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/test_2.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/test_2.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfaa9a38
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143775875
+ ->bits per elem = 14.377588
+ ->bytes = 17971985
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 13174 ms (collisions=1144)
+10000000,17971985,13174
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+      13004,411145 task-clock (msec)         #    0,986 CPUs utilized          
+             2 365 context-switches          #    0,182 K/sec                  
+                44 cpu-migrations            #    0,003 K/sec                  
+               970 page-faults               #    0,075 K/sec                  
+    33 408 696 154 cycles                    #    2,569 GHz                     [49,89%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     3 861 982 460 instructions              #    0,12  insns per cycle         [75,04%]
+       456 510 239 branches                  #   35,104 M/sec                   [75,00%]
+        45 267 641 branch-misses             #    9,92% of all branches         [75,12%]
+
+      13,194316911 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/test_3.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.55.8_24K/test_3.log
@@ -1,0 +1,27 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfdb2598
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 718879378
+ ->bits per elem = 14.377588
+ ->bytes = 89859923
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 68924 ms (collisions=5918)
+50000000,89859923,68924
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+      68352,388988 task-clock (msec)         #    0,991 CPUs utilized          
+             9 775 context-switches          #    0,143 K/sec                  
+               157 cpu-migrations            #    0,002 K/sec                  
+             1 148 page-faults               #    0,017 K/sec                  
+   175 705 958 387 cycles                    #    2,571 GHz                     [49,91%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+    19 303 786 717 instructions              #    0,11  insns per cycle         [74,91%]
+     2 276 628 618 branches                  #   33,307 M/sec                   [75,02%]
+       225 422 166 branch-misses             #    9,90% of all branches         [75,06%]
+
+      69,004981875 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/inxi.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/inxi.log
@@ -1,0 +1,7 @@
+CPU:       Quad core Intel Core i7-3632QM (-HT-MCP-) cache: 6144 KB 
+           clock speeds: max: 3200 MHz 1: 2985 MHz 2: 2641 MHz 3: 2540 MHz
+           4: 1687 MHz 5: 2972 MHz 6: 2730 MHz 7: 2521 MHz 8: 2822 MHz
+Memory:    Array-1 capacity: 16 GB devices: 2 EC: None
+           Device-1: Bottom-Slot 1(top) size: 4 GB speed: 1600 MHz type: DDR3
+           Device-2: Bottom-Slot 2(under) size: 4 GB speed: 1600 MHz
+           type: DDR3

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/lscpu.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/lscpu.log
@@ -1,0 +1,24 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                8
+On-line CPU(s) list:   0-7
+Thread(s) per core:    2
+Core(s) per socket:    4
+Socket(s):             1
+NUMA node(s):          1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 58
+Model name:            Intel(R) Core(TM) i7-3632QM CPU @ 2.20GHz
+Stepping:              9
+CPU MHz:               3045.367
+CPU max MHz:           3200,0000
+CPU min MHz:           1200,0000
+BogoMIPS:              4389.56
+Virtualization:        VT-x
+L1d cache:             32K
+L1i cache:             32K
+L2 cache:              256K
+L3 cache:              6144K
+NUMA node0 CPU(s):     0-7

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/test_1.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/test_1.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffc028cf5e0
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 71887937
+ ->bits per elem = 14.377588
+ ->bytes = 8985993
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 1103 ms (collisions=571)
+5000000,8985993,1103
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+       1099,632139      task-clock (msec)         #    0,995 CPUs utilized          
+             1 143      context-switches          #    0,001 M/sec                  
+                 3      cpu-migrations            #    0,003 K/sec                  
+               219      page-faults               #    0,199 K/sec                  
+     3 425 777 626      cycles                    #    3,115 GHz                    
+     2 150 042 772      stalled-cycles-frontend   #   62,76% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     1 608 826 550      instructions              #    0,47  insns per cycle        
+                                                  #    1,34  stalled cycles per insn
+       217 187 338      branches                  #  197,509 M/sec                  
+        16 133 779      branch-misses             #    7,43% of all branches        
+
+       1,105099369 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/test_2.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/test_2.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7fff841e9bb0
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143775875
+ ->bits per elem = 14.377588
+ ->bytes = 17971985
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 2651 ms (collisions=1144)
+10000000,17971985,2651
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+       2642,907823      task-clock (msec)         #    0,996 CPUs utilized          
+             2 675      context-switches          #    0,001 M/sec                  
+                 5      cpu-migrations            #    0,002 K/sec                  
+               880      page-faults               #    0,333 K/sec                  
+     7 965 843 923      cycles                    #    3,014 GHz                    
+     5 389 067 584      stalled-cycles-frontend   #   67,65% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     3 221 600 336      instructions              #    0,40  insns per cycle        
+                                                  #    1,67  stalled cycles per insn
+       435 081 411      branches                  #  164,622 M/sec                  
+        32 374 592      branch-misses             #    7,44% of all branches        
+
+       2,654620536 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/test_3.log
+++ b/perf_test/2015-09-08-22-23-18-0300_test_bit_set_bit-address-a-word-instead-of-a-byte/GenuineIntel-6.58.9_32K/test_3.log
@@ -1,0 +1,28 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffc7a3c6d20
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 718879378
+ ->bits per elem = 14.377588
+ ->bytes = 89859923
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 13992 ms (collisions=5918)
+50000000,89859923,13992
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+      13948,546522      task-clock (msec)         #    0,996 CPUs utilized          
+            14 558      context-switches          #    0,001 M/sec                  
+                 1      cpu-migrations            #    0,000 K/sec                  
+               546      page-faults               #    0,039 K/sec                  
+    42 795 663 976      cycles                    #    3,068 GHz                    
+    30 030 880 829      stalled-cycles-frontend   #   70,17% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+    16 102 999 826      instructions              #    0,38  insns per cycle        
+                                                  #    1,86  stalled cycles per insn
+     2 174 539 044      branches                  #  155,897 M/sec                  
+       161 817 373      branch-misses             #    7,44% of all branches        
+
+      14,003587975 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/0001-Group-bloom-filter-bits-into-CPU-L1-cache-sized-buck.patch
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/0001-Group-bloom-filter-bits-into-CPU-L1-cache-sized-buck.patch
@@ -1,0 +1,295 @@
+From ac0a990f6d4fd4d07539632297677aeee46da61c Mon Sep 17 00:00:00 2001
+From: m0nkeyc0der <noface@inbox.ru>
+Date: Sun, 6 Sep 2015 14:14:29 +0300
+Subject: [PATCH] Group bloom filter bits into CPU L1 cache sized buckets
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Profit from using L1 cache sized buckets comparing with
+the previous version was detected as 2.5X better CPU time for larger sized
+bloom filter via measuring 'perf test-libbloom -p 10000000 10000000' as
+
+      16948,503759 task-clock                #    0,994 CPUs utilized
+               105 context-switches          #    0,006 K/sec
+                20 cpu-migrations            #    0,001 K/sec
+             4 554 page-faults               #    0,269 K/sec
+    21 837 781 847 cycles                    #    1,288 GHz                     [49,99%]
+       466 360 932 stalled-cycles-frontend   #    2,14% frontend cycles idle    [50,00%]
+    15 421 088 731 stalled-cycles-backend    #   70,62% backend  cycles idle    [50,00%]
+     3 574 470 406 instructions              #    0,16  insns per cycle
+                                             #    4,31  stalled cycles per insn [50,01%]
+       437 580 007 branches                  #   25,818 M/sec                   [50,00%]
+        44 056 168 branch-misses             #   10,07% of all branches         [50,00%]
+
+      17,046271205 seconds time elapsed
+
+vs
+
+       6726,763600 task-clock                #    0,986 CPUs utilized
+               108 context-switches          #    0,016 K/sec
+                10 cpu-migrations            #    0,001 K/sec
+             8 970 page-faults               #    0,001 M/sec
+     8 651 681 442 cycles                    #    1,286 GHz                     [50,00%]
+       437 690 472 stalled-cycles-frontend   #    5,06% frontend cycles idle    [50,02%]
+     5 939 352 037 stalled-cycles-backend    #   68,65% backend  cycles idle    [50,02%]
+     3 405 553 987 instructions              #    0,39  insns per cycle
+                                             #    1,74  stalled cycles per insn [50,01%]
+       437 514 925 branches                  #   65,041 M/sec                   [49,98%]
+        44 079 507 branch-misses             #   10,07% of all branches         [50,00%]
+
+       6,822668794 seconds time elapsed
+
+where CPU is
+
+	Architecture:          x86_64
+	CPU op-mode(s):        32-bit, 64-bit
+	Byte Order:            Little Endian
+	CPU(s):                2
+	On-line CPU(s) list:   0,1
+	Thread(s) per core:    1
+	Core(s) per socket:    2
+	Socket(s):             1
+	NUMA node(s):          1
+	Vendor ID:             AuthenticAMD
+	CPU family:            16
+	Model:                 6
+	Stepping:              3
+	CPU MHz:               1296.694
+	BogoMIPS:              2593.38
+	Virtualization:        AMD-V
+	L1d cache:             64K
+	L1i cache:             64K
+	L2 cache:              1024K
+	NUMA node0 CPU(s):     0,1
+---
+ Makefile |   2 +-
+ bloom.c  | 134 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ bloom.h  |  17 ++++++++
+ 3 files changed, 150 insertions(+), 3 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 296fa85..3bb0df7 100644
+--- a/Makefile
++++ b/Makefile
+@@ -26,7 +26,7 @@ BUILD_OS := $(shell uname)
+ BUILD=$(TOP)/build
+ INC=-I$(TOP) -I$(TOP)/murmur2
+ LIB=-lm
+-CC=gcc -Wall ${OPT} ${MM} -std=c99 -fPIC
++CC=gcc -Wall ${OPT} ${MM} -std=c99 -D_GNU_SOURCE -fPIC
+ 
+ ifeq ($(MM),)
+ MM=-m32
+diff --git a/bloom.c b/bloom.c
+index d5c3869..7cabedd 100644
+--- a/bloom.c
++++ b/bloom.c
+@@ -9,6 +9,7 @@
+  * Refer to bloom.h for documentation on the public interfaces.
+  */
+ 
++#include <assert.h>
+ #include <fcntl.h>
+ #include <math.h>
+ #include <stdint.h>
+@@ -55,9 +56,12 @@ static int bloom_check_add(struct bloom * bloom,
+   register unsigned int x;
+   register unsigned int i;
+ 
++  unsigned       bucket_index = (a % bloom->buckets);
++  unsigned char *bucket_ptr   = (bloom->bf + (bucket_index << bloom->bucket_bytes_exponent));
++
+   for (i = 0; i < bloom->hashes; i++) {
+-    x = (a + i*b) % bloom->bits;
+-    if (test_bit_set_bit(bloom->bf, x, add))
++    x = (a + i*b) & bloom->bucket_bits_fast_mod_operand;
++    if (test_bit_set_bit(bucket_ptr, x, add))
+         hits++;
+   }
+ 
+@@ -69,6 +73,126 @@ static int bloom_check_add(struct bloom * bloom,
+ }
+ 
+ 
++/**
++ * gets file 1st line (w/o new line character)
++ */
++static const char* get_file_content(int dir, const char* file)
++{
++  static char buf[128];
++  FILE *fp;
++  int fd = openat(dir, file, O_RDONLY);
++  if (fd < 0)
++    return NULL;
++
++  fp = fdopen(fd, "r");
++  int ok = fscanf(fp, "%127s", buf);
++  fclose(fp); // this also closes fd
++
++  return ok? buf : NULL;
++}
++
++
++static int apply_size_suffix(int val, char suffix, const char* errmsg)
++{
++  switch (suffix) {
++  case 'K':
++    return val * 1024;
++  case 'M':
++    return val * 1024*1024;
++  default:
++    printf("%s: Unknown suffix '%c'\n", errmsg, suffix);
++    return -1;
++  }
++}
++
++
++static unsigned make_log2_friendly(unsigned cache_size)
++{
++  return 1 << (int)log2(cache_size);
++}
++
++
++static unsigned detect_bucket_size(unsigned fallback_size)
++{
++  int dir;
++  const char *s;
++  char size_suffix;
++  static int bucket_size = 0;
++  if (bucket_size)
++    return bucket_size > 0 ? (bucket_size / BLOOM_L1_CACHE_SIZE_DIV) : fallback_size;
++
++  dir = open("/sys/devices/system/cpu/cpu0/cache/index0", O_DIRECTORY);
++  if (dir < 0)
++  {
++    // sorry, this works for Linux only
++    bucket_size = -1;
++    return fallback_size;
++  }
++
++  // Double check cache is L1
++  if (!(s = get_file_content(dir, "level")) || strcmp(s, "1") != 0)
++  {
++    printf("Cannot detect L1 cache size in %s:%d\n", __FILE__, __LINE__);
++    goto out_err;
++  }
++
++  // Double check cache type is "Data"
++  if (!(s = get_file_content(dir, "type")) || strcmp(s, "Data") != 0)
++  {
++    printf("Cannot detect L1 cache size in %s:%d\n", __FILE__, __LINE__);
++    goto out_err;
++  }
++
++  // Fetch L1 cache size
++  if (!(s = get_file_content(dir, "size")) || sscanf(s, "%d%c%c", &bucket_size, &size_suffix, &size_suffix) != 2)
++  {
++    printf("Cannot detect L1 cache size in %s:%d\n", __FILE__, __LINE__);
++    goto out_err;
++  }
++
++  bucket_size = apply_size_suffix(bucket_size, size_suffix, "Cannot detect L1 cache size");
++  if (bucket_size < 0)
++    goto out_err;
++
++  bucket_size  = make_log2_friendly(bucket_size);
++  bucket_size /= BLOOM_L1_CACHE_SIZE_DIV;
++
++  close(dir);
++  return bucket_size;
++
++out_err:
++  bucket_size = -1;
++  close(dir);
++  return fallback_size;
++}
++
++
++static void setup_buckets(struct bloom * bloom)
++{
++  const unsigned cache_size = detect_bucket_size(BLOOM_BUCKET_SIZE_FALLBACK);
++
++  bloom->buckets      = (bloom->bytes / cache_size);
++  bloom->bucket_bytes = cache_size;
++
++  // make sure bloom buffer bytes and bucket_bytes are even
++  int not_even_by = (bloom->bytes % bloom->bucket_bytes);
++  if (not_even_by)
++  {
++    // adjust bytes
++    bloom->bytes += (bloom->bucket_bytes - not_even_by);
++    assert((bloom->bytes % bloom->bucket_bytes) == 0 || !"Oops! Should get even");
++    // adjust bits
++    bloom->bits = bloom->bytes * 8;
++    // adjust bits per element
++    bloom->bpe = bloom->bits*1. / bloom->entries;
++    // adjust buckets
++    bloom->buckets++;
++  }
++
++  bloom->bucket_bytes_exponent        = __builtin_ctz(cache_size);
++  bloom->bucket_bits_fast_mod_operand = (cache_size * 8 - 1);
++}
++
+ int bloom_init(struct bloom * bloom, int entries, double error)
+ {
+   bloom->ready = 0;
+@@ -95,6 +219,8 @@ int bloom_init(struct bloom * bloom, int entries, double error)
+ 
+   bloom->hashes = (int)ceil(0.693147180559945 * bloom->bpe);  // ln(2)
+ 
++  setup_buckets(bloom);
++
+   bloom->bf = (unsigned char *)calloc(bloom->bytes, sizeof(unsigned char));
+   if (bloom->bf == NULL) {
+     return 1;
+@@ -125,6 +251,10 @@ void bloom_print(struct bloom * bloom)
+   (void)printf(" ->bits = %d\n", bloom->bits);
+   (void)printf(" ->bits per elem = %f\n", bloom->bpe);
+   (void)printf(" ->bytes = %d\n", bloom->bytes);
++  (void)printf(" ->buckets = %u\n", bloom->buckets);
++  (void)printf(" ->bucket_bytes = %u\n", bloom->bucket_bytes);
++  (void)printf(" ->bucket_bytes_exponent = %u\n", bloom->bucket_bytes_exponent);
++  (void)printf(" ->bucket_bits_fast_mod_operand = 0%o\n", bloom->bucket_bits_fast_mod_operand);
+   (void)printf(" ->hash functions = %d\n", bloom->hashes);
+ }
+ 
+diff --git a/bloom.h b/bloom.h
+index 2ca87ce..48ad04c 100644
+--- a/bloom.h
++++ b/bloom.h
+@@ -8,6 +8,17 @@
+ #ifndef _BLOOM_H
+ #define _BLOOM_H
+ 
++#define BLOOM_BUCKET_SIZE_FALLBACK (8 * 1024)
++
++/**
++ * It was found that using multiplier x0.5
++ * for CPU L1 cache size is more effective
++ * in terms of CPU usage and, surprisingly, collisions number.
++ *
++ * Feel free to tune this constant the way it will work for you.
++ */
++#define BLOOM_L1_CACHE_SIZE_DIV 1
++
+ /** ***************************************************************************
+  * Structure to keep track of one bloom filter.  Caller needs to
+  * allocate this and pass it to the functions below. First call for
+@@ -28,6 +39,12 @@ struct bloom
+   // Fields below are private to the implementation. These may go away or
+   // change incompatibly at any moment. Client code MUST NOT access or rely
+   // on these.
++  unsigned buckets;
++  unsigned bucket_bytes;
++  // x86 CPU divide by/multiply by operation optimization helpers
++  unsigned bucket_bytes_exponent;
++  unsigned bucket_bits_fast_mod_operand;
++
+   double bpe;
+   unsigned char * bf;
+   int ready;
+-- 
+2.1.4
+

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/inxi.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/inxi.log
@@ -1,0 +1,2 @@
+CPU:       Quad core Intel Pentium CPU N3530 (-MCP-) cache: 1024 KB flags: (lm nx pae sse sse2 sse3 sse4_1 sse4_2 ssse3 vmx) 
+           Clock Speeds: 1: 830.00 MHz 2: 830.00 MHz 3: 1328.00 MHz 4: 1992.00 MHz

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/lscpu.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/lscpu.log
@@ -1,0 +1,18 @@
+Architecture:          i686
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                4
+On-line CPU(s) list:   0-3
+Thread(s) per core:    1
+Core(s) per socket:    4
+Socket(s):             1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 55
+Stepping:              8
+CPU MHz:               2159.000
+BogoMIPS:              4332.99
+Virtualization:        VT-x
+L1d cache:             24K
+L1i cache:             32K
+L2 cache:              1024K

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/test_1.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/test_1.log
@@ -1,0 +1,31 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfe80c18
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 71958528
+ ->bits per elem = 14.391706
+ ->bytes = 8994816
+ ->buckets = 549
+ ->bucket_bytes = 16384
+ ->bucket_bytes_exponent = 14
+ ->bucket_bits_fast_mod_operand = 0377777
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 3722 ms (collisions=598)
+5000000,8994816,3722
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+       3693,870522 task-clock (msec)         #    0,992 CPUs utilized          
+               493 context-switches          #    0,133 K/sec                  
+                14 cpu-migrations            #    0,004 K/sec                  
+             1 508 page-faults               #    0,408 K/sec                  
+     9 475 368 792 cycles                    #    2,565 GHz                     [50,33%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     1 807 982 063 instructions              #    0,19  insns per cycle         [75,25%]
+       227 514 148 branches                  #   61,592 M/sec                   [75,20%]
+        22 808 940 branch-misses             #   10,03% of all branches         [74,52%]
+
+       3,724666346 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/test_2.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/test_2.log
@@ -1,0 +1,31 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfcbe9b8
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143785984
+ ->bits per elem = 14.378598
+ ->bytes = 17973248
+ ->buckets = 1097
+ ->bucket_bytes = 16384
+ ->bucket_bytes_exponent = 14
+ ->bucket_bits_fast_mod_operand = 0377777
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 7610 ms (collisions=1277)
+10000000,17973248,7610
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+       7557,812494 task-clock (msec)         #    0,993 CPUs utilized          
+               920 context-switches          #    0,122 K/sec                  
+                31 cpu-migrations            #    0,004 K/sec                  
+             1 804 page-faults               #    0,239 K/sec                  
+    19 374 995 009 cycles                    #    2,564 GHz                     [49,98%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+     3 612 746 904 instructions              #    0,19  insns per cycle         [75,08%]
+       453 418 573 branches                  #   59,993 M/sec                   [75,06%]
+        45 566 884 branch-misses             #   10,05% of all branches         [74,98%]
+
+       7,613104955 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/test_3.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.55.8_24K/test_3.log
@@ -1,0 +1,31 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0xbfa96028
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 718929920
+ ->bits per elem = 14.378598
+ ->bytes = 89866240
+ ->buckets = 5485
+ ->bucket_bytes = 16384
+ ->bucket_bytes_exponent = 14
+ ->bucket_bits_fast_mod_operand = 0377777
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 38697 ms (collisions=6176)
+50000000,89866240,38697
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+      38193,054088 task-clock (msec)         #    0,987 CPUs utilized          
+             6 470 context-switches          #    0,169 K/sec                  
+               121 cpu-migrations            #    0,003 K/sec                  
+             2 161 page-faults               #    0,057 K/sec                  
+    98 033 774 563 cycles                    #    2,567 GHz                     [49,96%]
+   <not supported> stalled-cycles-frontend 
+   <not supported> stalled-cycles-backend  
+    18 046 977 873 instructions              #    0,18  insns per cycle         [74,94%]
+     2 266 340 823 branches                  #   59,339 M/sec                   [75,00%]
+       227 874 640 branch-misses             #   10,05% of all branches         [75,04%]
+
+      38,700117060 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/inxi.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/inxi.log
@@ -1,0 +1,7 @@
+CPU:       Quad core Intel Core i7-3632QM (-HT-MCP-) cache: 6144 KB 
+           clock speeds: max: 3200 MHz 1: 2978 MHz 2: 2066 MHz 3: 3014 MHz
+           4: 1232 MHz 5: 3045 MHz 6: 2766 MHz 7: 2910 MHz 8: 2352 MHz
+Memory:    Array-1 capacity: 16 GB devices: 2 EC: None
+           Device-1: Bottom-Slot 1(top) size: 4 GB speed: 1600 MHz type: DDR3
+           Device-2: Bottom-Slot 2(under) size: 4 GB speed: 1600 MHz
+           type: DDR3

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/lscpu.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/lscpu.log
@@ -1,0 +1,24 @@
+Architecture:          x86_64
+CPU op-mode(s):        32-bit, 64-bit
+Byte Order:            Little Endian
+CPU(s):                8
+On-line CPU(s) list:   0-7
+Thread(s) per core:    2
+Core(s) per socket:    4
+Socket(s):             1
+NUMA node(s):          1
+Vendor ID:             GenuineIntel
+CPU family:            6
+Model:                 58
+Model name:            Intel(R) Core(TM) i7-3632QM CPU @ 2.20GHz
+Stepping:              9
+CPU MHz:               3023.968
+CPU max MHz:           3200,0000
+CPU min MHz:           1200,0000
+BogoMIPS:              4389.56
+Virtualization:        VT-x
+L1d cache:             32K
+L1i cache:             32K
+L2 cache:              256K
+L3 cache:              6144K
+NUMA node0 CPU(s):     0-7

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/test_1.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/test_1.log
@@ -1,0 +1,32 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffda0f33fe0
+ ->entries = 5000000
+ ->error = 0.001000
+ ->bits = 72089600
+ ->bits per elem = 14.417920
+ ->bytes = 9011200
+ ->buckets = 275
+ ->bucket_bytes = 32768
+ ->bucket_bytes_exponent = 15
+ ->bucket_bits_fast_mod_operand = 0777777
+ ->hash functions = 10
+Added 5000000 elements of size 4, took 771 ms (collisions=647)
+5000000,9011200,771
+
+ Performance counter stats for '.../test-libbloom -p 5000000 5000000':
+
+        767,799416      task-clock (msec)         #    0,995 CPUs utilized          
+               776      context-switches          #    0,001 M/sec                  
+                 5      cpu-migrations            #    0,007 K/sec                  
+               387      page-faults               #    0,504 K/sec                  
+     2 262 144 306      cycles                    #    2,946 GHz                    
+     1 342 018 875      stalled-cycles-frontend   #   59,33% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     1 610 585 112      instructions              #    0,71  insns per cycle        
+                                                  #    0,83  stalled cycles per insn
+       220 885 586      branches                  #  287,687 M/sec                  
+        15 468 634      branch-misses             #    7,00% of all branches        
+
+       0,772011247 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/test_2.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/test_2.log
@@ -1,0 +1,32 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffcff2fbb80
+ ->entries = 10000000
+ ->error = 0.001000
+ ->bits = 143917056
+ ->bits per elem = 14.391706
+ ->bytes = 17989632
+ ->buckets = 549
+ ->bucket_bytes = 32768
+ ->bucket_bytes_exponent = 15
+ ->bucket_bits_fast_mod_operand = 0777777
+ ->hash functions = 10
+Added 10000000 elements of size 4, took 1659 ms (collisions=1267)
+10000000,17989632,1659
+
+ Performance counter stats for '.../test-libbloom -p 10000000 10000000':
+
+       1651,654530      task-clock (msec)         #    0,995 CPUs utilized          
+             1 665      context-switches          #    0,001 M/sec                  
+                 0      cpu-migrations            #    0,000 K/sec                  
+               683      page-faults               #    0,414 K/sec                  
+     5 076 266 687      cycles                    #    3,073 GHz                    
+     3 250 204 701      stalled-cycles-frontend   #   64,03% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+     3 173 618 644      instructions              #    0,63  insns per cycle        
+                                                  #    1,02  stalled cycles per insn
+       433 672 903      branches                  #  262,569 M/sec                  
+        30 788 566      branch-misses             #    7,10% of all branches        
+
+       1,659990839 seconds time elapsed
+

--- a/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/test_3.log
+++ b/perf_test/2015-09-08-22-33-37-0300_Group-bloom-filter-bits-into-CPU-L1-cache-sized-buckets/GenuineIntel-6.58.9_32K/test_3.log
@@ -1,0 +1,32 @@
+testing libbloom...
+----- perf_loop -----
+bloom at 0x7ffdcee81f20
+ ->entries = 50000000
+ ->error = 0.001000
+ ->bits = 719060992
+ ->bits per elem = 14.381220
+ ->bytes = 89882624
+ ->buckets = 2743
+ ->bucket_bytes = 32768
+ ->bucket_bytes_exponent = 15
+ ->bucket_bits_fast_mod_operand = 0777777
+ ->hash functions = 10
+Added 50000000 elements of size 4, took 9063 ms (collisions=6191)
+50000000,89882624,9063
+
+ Performance counter stats for '.../test-libbloom -p 50000000 50000000':
+
+       9019,967943      task-clock (msec)         #    0,995 CPUs utilized          
+             9 092      context-switches          #    0,001 M/sec                  
+                 4      cpu-migrations            #    0,000 K/sec                  
+             1 039      page-faults               #    0,115 K/sec                  
+    27 481 256 174      cycles                    #    3,047 GHz                    
+    18 467 901 500      stalled-cycles-frontend   #   67,20% frontend cycles idle   
+                 0      stalled-cycles-backend    #    0,00% backend  cycles idle   
+    15 907 667 558      instructions              #    0,58  insns per cycle        
+                                                  #    1,16  stalled cycles per insn
+     2 175 474 944      branches                  #  241,184 M/sec                  
+       153 241 332      branch-misses             #    7,04% of all branches        
+
+       9,065155409 seconds time elapsed
+


### PR DESCRIPTION
Could you check out 'Group bloom filter bits into CPU L1 cache sized buckets' optimization and submit your report from running make perf_test target prior and after merging aforementioned commit?
