### PR TITLE
Extend RPATH setting for GNU/kFreeBSD and Hurd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ LD_SONAME=-Wl,-soname,$(BLOOM_SONAME)
 SO=so
 
 
-ifeq ($(BUILD_OS),Linux)
+ifeq ($(BUILD_OS),$(filter $(BUILD_OS), GNU/kFreeBSD GNU Linux))
 RPATH=-Wl,-rpath,$(BUILD)
 endif
 


### PR DESCRIPTION
Fix FTBFS issue for Debian on GNU/kFreeBSD and Hurd
result of command `uname` can reference:
  http://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux