### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ $(BUILD)/test-libbloom: $(TESTDIR)/test.c $(BUILD)/$(SO_VERSIONED)
 	    $(COM) test.o -L$(BUILD) $(RPATH) -lbloom -o test-libbloom)
 
 $(BUILD)/test-basic: $(TESTDIR)/basic.c $(BUILD)/libbloom.a
-	$(COM) -I$(TOP) $(LIB) \
-	    $(TESTDIR)/basic.c $(BUILD)/libbloom.a -o $(BUILD)/test-basic
+	$(COM) -I$(TOP) \
+	    $(TESTDIR)/basic.c $(BUILD)/libbloom.a $(LIB) -o $(BUILD)/test-basic
 
 $(BUILD)/%.o: %.c
 	mkdir -p $(BUILD)


### PR DESCRIPTION
The placement of the dependant libs is meaningful. Prior to this change attempts to build the test objects failed with an undefined reference to `log`:

```
$ make test
cc   -Wall -O3 -m64 -std=c99 -fPIC -DBLOOM_VERSION=1.5 -I/home/poprocks/Dropbox/Code/C/libbloom -c /home/poprocks/Dropbox/Code/C/libbloom/misc/test/test.c -o /home/poprocks/Dropbox/Code/C/libbloom/build/test.o
(cd /home/poprocks/Dropbox/Code/C/libbloom/build && \
    cc   -Wall -O3 -m64 -std=c99 -fPIC -DBLOOM_VERSION=1.5 test.o -L/home/poprocks/Dropbox/Code/C/libbloom/build -Wl,-rpath,/home/poprocks/Dropbox/Code/C/libbloom/build -lbloom -o test-libbloom)
cc   -Wall -O3 -m64 -std=c99 -fPIC -DBLOOM_VERSION=1.5 -I/home/poprocks/Dropbox/Code/C/libbloom -lm \
    /home/poprocks/Dropbox/Code/C/libbloom/misc/test/basic.c /home/poprocks/Dropbox/Code/C/libbloom/build/libbloom.a -o /home/poprocks/Dropbox/Code/C/libbloom/build/test-basic
/home/poprocks/Dropbox/Code/C/libbloom/build/libbloom.a(bloom.o): In function `bloom_init':
bloom.c:(.text+0x40): undefined reference to `log'
collect2: error: ld returned 1 exit status
Makefile:108: recipe for target '/home/poprocks/Dropbox/Code/C/libbloom/build/test-basic' failed
make: *** [/home/poprocks/Dropbox/Code/C/libbloom/build/test-basic] Error 1
```