### PR TITLE
Adds a simple bloom_reset() function

### DIFF
--- a/bloom.c
+++ b/bloom.c
@@ -150,6 +150,14 @@ void bloom_free(struct bloom * bloom)
 }
 
 
+int bloom_reset(struct bloom * bloom)
+{
+  if (!bloom->ready) return 1;
+  memset(bloom->bf, 0, bloom->bytes);
+  return 0;
+}
+
+
 const char * bloom_version()
 {
   return MAKESTRING(BLOOM_VERSION);

--- a/bloom.h
+++ b/bloom.h
@@ -140,6 +140,23 @@ void bloom_print(struct bloom * bloom);
  */
 void bloom_free(struct bloom * bloom);
 
+/** ***************************************************************************
+ * Erase internal storage.
+ *
+ * Erases all elements. Upon return, the bloom struct returns to its initial
+ * (initialized) state.
+ *
+ * Parameters:
+ * -----------
+ *     bloom  - Pointer to an allocated struct bloom (see above).
+ *
+ * Return:
+ *     0 - on success
+ *     1 - on failure
+ *
+ */
+int bloom_reset(struct bloom * bloom);
+
 
 /** ***************************************************************************
  * Returns version string compiled into library.


### PR DESCRIPTION
👋 
add bloom_reset function which preserves the allocated buffer, but erases all elements.

Might come handy in cases of a large enough allocation, and the need to frequently erase all elements. e.g. system reconfigurations.