### PR TITLE
!(Error >=)

### DIFF
--- a/bloom.c
+++ b/bloom.c
@@ -88,7 +88,7 @@ int bloom_init(struct bloom * bloom, int entries, double error)
 {
   bloom->ready = 0;
 
-  if (entries < 1000 || error == 0) {
+  if (entries < 1000 || error == 0 || error >= 1) {
     return 1;
   }
 


### PR DESCRIPTION
Error must be strictly smaller than 1.
Larger than 1 is impossible and equal to 1 will make bpe = 0 since log(1) = 0.